### PR TITLE
Change /auth to /login

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ KSK has three api endpoints for demonstration purpose.
 You need to setup domains white list before you can use any api endpoints in React, Angular or Vuejs application.
 You'll find the white list at: `src/config/index.js` (someone please help me turn the config file into multi enviroments config!)
 
-#### /auth
+#### /login
 Login to get the jwt token.
 
 - request config:


### PR DESCRIPTION
Defined path "/login" in /src/routers/router-auth.js but README.md use "/auth" which is not working.